### PR TITLE
Add a way to dedup locales

### DIFF
--- a/js/cloneToNewSpace.js
+++ b/js/cloneToNewSpace.js
@@ -3,7 +3,7 @@ import ContentfulManagement from 'contentful-management';
 import spaceExport from 'contentful-export';
 import spaceImport from 'contentful-import';
 import chalk from 'chalk';
-
+import lodash from 'lodash';
 
 let cloneToNewSpace = () => {
   const client = ContentfulManagement.createClient({
@@ -86,6 +86,8 @@ let cloneToNewSpace = () => {
       })
     })
     .then((output) => {
+      let dedupLocales = lodash.uniqBy(output.locales, 'code');
+      output.locales = dedupLocales;
       console.log(chalk.green('\n Cloned space content found \n'))
       let uploadOptions = {
         content: output,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hawker-localization",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Automatic localization of translated content",
   "main": "getContentful.js",
   "scripts": {
@@ -29,6 +29,7 @@
     "contentful-import": "^2.4.0",
     "contentful-management": "^1.3.1",
     "fs": "0.0.1-security",
+    "lodash": "^4.17.4",
     "xlsx": "^0.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This patch dedups the locales to prevent errors from 422 status
code responses.

@AndrewBresee 